### PR TITLE
feat: added `go:lint` namespace which provides different ways to call golangci-lint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,6 @@
 version: '3'
 
+output: prefixed
+
 includes:
   go: ./go

--- a/go/Taskfile.yml
+++ b/go/Taskfile.yml
@@ -7,6 +7,9 @@ vars:
   COVER_FILE: '{{.COVER_NAME}}.out'
   COVER_HTML: '{{.COVER_NAME}}.html'
 
+includes:
+  lint: ./lint
+
 tasks:
 
   test:
@@ -24,14 +27,3 @@ tasks:
       - cmd: go tool cover -html={{.COVER_FILE}} -o {{.COVER_HTML}}
       - cmd: cmd /c start {{.COVER_HTML}}
         platforms: [windows]
-
-  lint:
-    desc: 'runs `golangci-lint` with the first recursively found config file'
-    dir: '{{.USER_WORKING_DIR}}'
-    vars:
-      CONFIG_FILE:
-        sh: where /r "{{.USER_WORKING_DIR}}" .golangci.*
-    cmds:
-      - cmd: 'echo found config file: "{{.CONFIG_FILE}}"'
-      - cmd: golangci-lint run --config="{{.CONFIG_FILE}}"
-    platforms: [windows]

--- a/go/lint/Taskfile.yml
+++ b/go/lint/Taskfile.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+output: prefixed
+
+tasks:
+
+  manual:
+    desc: 'runs `golangci-lint` with provided CLI arguments'
+    dir: '{{.USER_WORKING_DIR}}'
+    cmds:
+      - cmd: golangci-lint run {{.CLI_ARGS}}
+    platforms: [windows]
+
+  auto:
+    desc: 'runs `golangci-lint` with first recursively found config file, also supports CLI arguments'
+    dir: '{{.USER_WORKING_DIR}}'
+    vars:
+      CONFIG_FILE:
+        sh: where /r "{{.USER_WORKING_DIR}}" .golangci.*
+    cmds:
+      - cmd: 'echo found config file: "{{.CONFIG_FILE}}"'
+      - cmd: golangci-lint run --config="{{.CONFIG_FILE}}" {{.CLI_ARGS}}
+    platforms: [windows]


### PR DESCRIPTION
Resolves #9.